### PR TITLE
Custom Credential Type for CyberArk PAS REST API Credentials

### DIFF
--- a/custom-cred-types/cyberark-pas-restapi/README.md
+++ b/custom-cred-types/cyberark-pas-restapi/README.md
@@ -1,0 +1,32 @@
+# CyberArk PAS REST API
+
+Custom Credential Type for Ansible Tower
+
+## Installation
+
+1. Login to Ansible Tower as a Tower Administrator.
+2. Under Administration, click on Credential Type.
+3. Click the green [ + ] in the top right-hand corner to create a new Custom Credential Type.
+4. Set the name of your Credential Type. e.g. `CyberArk PAS REST API`
+5. Under `Input Configuration` select `YAML`.
+6. Copy and paste the [input.yml](input.yml) into the text field for `Input Configuration`.
+7. Under `Injector Configuration` select `YAML`.
+8. Copy and paste the [injector.yml](injector.yml) into the text field for `Injector Configuration`.
+9. Click `Save` at the bottom to save the Custom Credential Type.
+
+## Usage
+
+Reference the following environment variables within your Ansible Playbook when using this Credential Type:
+
+* `CYBERARK_API_URL` \
+This is the Base URI of your CyberArk Password Vault Web Access (PVWA). _e.g. `https://pvwa.cyberark.com`_
+
+* `CYBERARK_API_USERNAME` \
+This is the username to use when logging into the CyberArk PAS Web Services SDK (REST API).
+
+* `CYBERARK_API_PASSWORD` \
+This is the password associated with the username provided for login.
+
+## Maintainer
+
+Joe Garcia, CISSP - DevOps Security Engineer, CyberArk - [@infamousjoeg](https://github.com/infamousjoeg)

--- a/custom-cred-types/cyberark-pas-restapi/injector.yml
+++ b/custom-cred-types/cyberark-pas-restapi/injector.yml
@@ -1,0 +1,4 @@
+extra_vars:
+  CYBERARK_API_PASSWORD: '{{ password }}'
+  CYBERARK_API_URL: '{{ pvwa_url }}'
+  CYBERARK_API_USERNAME: '{{ username }}'

--- a/custom-cred-types/cyberark-pas-restapi/input.yml
+++ b/custom-cred-types/cyberark-pas-restapi/input.yml
@@ -1,0 +1,18 @@
+fields:
+  - id: username
+    type: string
+    label: Username
+    help_text: CyberArk REST API Username
+  - id: password
+    type: string
+    label: Password
+    secret: true
+    help_text: CyberArk REST API Password
+  - id: pvwa_url
+    type: string
+    label: PVWA URL
+    help_text: 'CyberArk PVWA URL e.g. https://pvwa.cyberark.com'
+required:
+  - username
+  - password
+  - pvwa_url


### PR DESCRIPTION
These are the Input and Injector YAML code for creating a custom Credential Type for a CyberArk REST API User/Password/Base URI to be stored within Ansible Tower Credentials and used with the CyberArk Collection.

It includes a README file with installation and usage instructions.