### PR TITLE
v2 API session token support

### DIFF
--- a/plugins/modules/cyberark_authentication.py
+++ b/plugins/modules/cyberark_authentication.py
@@ -266,8 +266,10 @@ def processAuthentication(module):
             try:
                 if use_shared_logon:
                     token = json.loads(response.read())["LogonResult"]
-                else:
+                elif json.loads(response.read())["CyberArkLogonResult"]:
                     token = json.loads(response.read())["CyberArkLogonResult"]
+                else:
+                    token = json.loads(response.read()).strip('"')
             except Exception as e:
                 module.fail_json(
                     msg="Error obtaining token\n%s" % (to_text(e)),


### PR DESCRIPTION
Added additional conditional for if there is no `CyberArkLogonResult` key in the JSON response of `cyberark_authentication`.