### PR TITLE
Fix #8 - Add additional authentication method support for v1 API

### DIFF
--- a/plugins/modules/cyberark_authentication.py
+++ b/plugins/modules/cyberark_authentication.py
@@ -325,7 +325,7 @@ def main():
         "username": {"type": "str"},
         "password": {"type": "str", "no_log": True},
         "new_password": {"type": "str", "no_log": True},
-        "auth_type": {"default": "cyberark", "type": "str"}
+        "auth_type": {"default": "cyberark", "type": "str"},
         "use_shared_logon_authentication": {"default": False, "type": "bool"},
         "use_radius_authentication": {"default": False, "type": "bool"},
         "connection_number": {"type": "int"},

--- a/plugins/modules/cyberark_authentication.py
+++ b/plugins/modules/cyberark_authentication.py
@@ -266,8 +266,10 @@ def processAuthentication(module):
             try:
                 if use_shared_logon:
                     token = json.loads(response.read())["LogonResult"]
-                else:
+                elif json.loads(response.read())["CyberArkLogonResult"]:
                     token = json.loads(response.read())["CyberArkLogonResult"]
+                else:
+                    token = json.loads(response.read()).strip('"')
             except Exception as e:
                 module.fail_json(
                     msg="Error obtaining token\n%s" % (to_text(e)),


### PR DESCRIPTION
Added a new `auth_type` module variable to accept `cyberark`, `ldap`, `windows` authentication methods.

The default value of `auth_type` is `cyberark`.