### PR TITLE
Enhance python2/3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ None.
 
 #### Python3
 
-- The modules were updated to be in python 3, for python 2 refer to the following commit: f47f6708c40411368f2bfe8245fcb7514867e0e9
+- The modules will work with either python2 or python3.
 
 #### Author Information
 - CyberArk Business Development Technical Team 

--- a/plugins/modules/cyberark_account.py
+++ b/plugins/modules/cyberark_account.py
@@ -375,15 +375,9 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.error import HTTPError
-import urllib.request, urllib.parse, urllib.error
-
+from ansible.module_utils.six.moves.urllib.parse import quote
+from ansible.module_utils.six.moves.http_client import HTTPException
 import json
-
-try:
-    import http.client
-except ImportError:
-    # Python 3
-    import http.client as httplib
 import logging
 
 _empty = object()
@@ -655,7 +649,7 @@ def update_account(module, existing_account):
 
                 #                return (True, result, response.getcode())
 
-                except (HTTPError, http.client.HTTPException) as http_exception:
+                except (HTTPError, HTTPException) as http_exception:
 
                     if isinstance(http_exception, HTTPError):
                         res = json.load(http_exception)
@@ -790,7 +784,7 @@ def add_account(module):
 
             return (True, result, response.getcode())
 
-    except (HTTPError, http.client.HTTPException) as http_exception:
+    except (HTTPError, HTTPException) as http_exception:
 
         if isinstance(http_exception, HTTPError):
             res = json.load(http_exception)
@@ -857,7 +851,7 @@ def delete_account(module, existing_account):
 
             return (True, result, response.getcode())
 
-        except (HTTPError, http.client.HTTPException) as http_exception:
+        except (HTTPError, HTTPException) as http_exception:
 
             if isinstance(http_exception, HTTPError):
                 res = json.load(http_exception)
@@ -980,7 +974,7 @@ def reset_account_if_needed(module, existing_account):
 
                 return (True, result, response.getcode())
 
-            except (HTTPError, http.client.HTTPException) as http_exception:
+            except (HTTPError, HTTPException) as http_exception:
 
                 if isinstance(http_exception, HTTPError):
                     res = json.load(http_exception)
@@ -1062,7 +1056,7 @@ def get_account(module):
     identified_by_fields = module.params["identified_by"].split(",")
     logging.debug("Identified_by: %s", json.dumps(identified_by_fields))
     safe_filter = (
-        urllib.parse.quote("safeName eq ") + urllib.parse.quote(module.params["safe"])
+        quote("safeName eq ") + quote(module.params["safe"])
         if "safe" in module.params and module.params["safe"] is not None
         else None
     )
@@ -1085,7 +1079,7 @@ def get_account(module):
     if search_string is not None and safe_filter is not None:
         end_point = "/PasswordVault/api/accounts?filter=%s&search=%s" % (
             safe_filter,
-            urllib.parse.quote(search_string.lstrip()),
+            quote(search_string.lstrip()),
         )
     elif search_string is not None:
         end_point = ("/PasswordVault/api/accounts?search=%s") % (search_string.lstrip())
@@ -1161,7 +1155,7 @@ def get_account(module):
             else:
                 return (how_many == 1, first_record_found, response.getcode())
 
-    except (HTTPError, http.client.HTTPException) as http_exception:
+    except (HTTPError, HTTPException) as http_exception:
 
         if http_exception.code == 404:
             return (False, None, http_exception.code)

--- a/plugins/modules/cyberark_authentication.py
+++ b/plugins/modules/cyberark_authentication.py
@@ -145,13 +145,8 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.error import HTTPError
+from ansible.module_utils.six.moves.http_client import HTTPException
 import json
-
-try:
-    import http.client
-except ImportError:
-    # Python 3
-    import http.client as httplib
 
 
 def processAuthentication(module):
@@ -242,7 +237,7 @@ def processAuthentication(module):
             validate_certs=validate_certs,
         )
 
-    except (HTTPError, http.client.HTTPException) as http_exception:
+    except (HTTPError, HTTPException) as http_exception:
 
         module.fail_json(
             msg=(

--- a/plugins/modules/cyberark_credential.py
+++ b/plugins/modules/cyberark_credential.py
@@ -207,13 +207,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.urllib.parse import quote
+from ansible.module_utils.six.moves.http_client import HTTPException
 import json
-
-try:
-    import http.client
-except ImportError:
-    # Python 3
-    import http.client as httplib
 
 
 def retrieve_credential(module):
@@ -264,7 +259,7 @@ def retrieve_credential(module):
             client_key=client_key,
         )
 
-    except (HTTPError, http.client.HTTPException) as http_exception:
+    except (HTTPError, HTTPException) as http_exception:
 
         module.fail_json(
             msg=(

--- a/plugins/modules/cyberark_user.py
+++ b/plugins/modules/cyberark_user.py
@@ -177,8 +177,8 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.six.moves import http_client as httplib
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.urls import open_url
+from ansible.module_utils.six.moves.urllib.parse import quote
 import logging
-import urllib.request, urllib.parse, urllib.error
 
 
 def user_details(module):
@@ -472,9 +472,7 @@ def user_add_to_group(module):
 
     # Prepare result, end_point, headers and payload
     result = {}
-    end_point = ("/PasswordVault/api/UserGroups/{0}/Members").format(
-        urllib.parse.quote(vault_id)
-    )
+    end_point = ("/PasswordVault/api/UserGroups/{0}/Members").format(quote(vault_id))
 
     headers = {"Content-Type": "application/json"}
     headers["Authorization"] = cyberark_session["token"]


### PR DESCRIPTION
### What does this PR do?
- This PR incorporates additional imports from ansible.module_utils.six.moves to make the modules work with either python2 or python3.
- If the existing tests test the error conditions (i.e. catching the HTTPExceptions) no additional tests should be required. Please note, I performed py_compile and flake8 tests against the modules but I do not have an instance of CyberArk stood up to run the playbooks in the tests directory. These tests were run against: ansible 2.10.8 and ansible 2.9.18 with python versions 3.9.2 and 2.7.16
- There are no relevant screen shots with this PR.

### What ticket does this PR close?
Resolves None

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
