### PR TITLE
Fixes and Enhancements for cyberark_user

### DIFF
--- a/plugins/modules/cyberark_user.py
+++ b/plugins/modules/cyberark_user.py
@@ -139,11 +139,11 @@ options:
     authorization:
         description:
             - A list of authorization options for this user.
-            - Options can include AddSafe and AuditUsers
+            - Options can include AddSafes and AuditUsers
             - The default provides backwards compatability with older versions of the collection
         type: list
         default:
-          - AddSafe
+          - AddSafes
           - AuditUsers
 """
 
@@ -343,7 +343,7 @@ def user_add_or_update(module, HTTPMethod, existing_info):
         payload["Location"] = module.params["location"]
 
     if module.params.get("authorization", None) is not None:
-        payload["VaultAuthorization"] = module.params["authorization"]
+        payload["vaultAuthorization"] = module.params["authorization"]
 
     # --------------------------------------------------------------
     logging.debug(
@@ -723,7 +723,7 @@ def main():
             member_type=dict(type="str"),
             domain_name=dict(type="str"),
             timeout=dict(type="float", default=10),
-            authorization=dict(type="list", required=False, default=[ 'AddSafe', 'AuditUsers' ]),
+            authorization=dict(type="list", required=False, default=[ 'AddSafes', 'AuditUsers' ]),
         )
     )
 

--- a/plugins/modules/cyberark_user.py
+++ b/plugins/modules/cyberark_user.py
@@ -136,6 +136,15 @@ options:
             - The ID of the user to delete
             - Prefered over username
         type: int
+    authorization:
+        description:
+            - A list of authorization options for this user.
+            - Options can include AddSafe and AuditUsers
+            - The default provides backwards compatability with older versions of the collection
+        type: list
+        default:
+          - AddSafe
+          - AuditUsers
 """
 
 EXAMPLES = r"""
@@ -332,6 +341,9 @@ def user_add_or_update(module, HTTPMethod, existing_info):
 
     if "location" in module.params and module.params["location"] is not None:
         payload["Location"] = module.params["location"]
+
+    if module.params.get("authorization", None) is not None:
+        payload["VaultAuthorization"] = module.params["authorization"]
 
     # --------------------------------------------------------------
     logging.debug(
@@ -697,6 +709,7 @@ def main():
             member_type=dict(type="str"),
             domain_name=dict(type="str"),
             timeout=dict(type="float", default=10),
+            authorization=dict(type="list", required=False, default=[ 'AddSafe', 'AuditUsers' ]),
         )
     )
 

--- a/plugins/modules/cyberark_user.py
+++ b/plugins/modules/cyberark_user.py
@@ -194,6 +194,9 @@ from ansible.module_utils.six.moves.urllib.parse import quote
 import logging
 
 
+def construct_url(api_base_url, end_point):
+    return "{}/{}".format(api_base_url.rstrip("/"), end_point.lstrip("/"))
+
 def user_details(module):
 
     # Get username from module parameters, and api base url
@@ -206,6 +209,7 @@ def user_details(module):
     # Prepare result, end_point, and headers
     result = {}
     end_point = "/PasswordVault/WebServices/PIMServices.svc/Users/{0}".format(username)
+    url = construct_url(api_base_url, end_point)
 
     headers = {"Content-Type": "application/json"}
     headers["Authorization"] = cyberark_session["token"]
@@ -213,7 +217,7 @@ def user_details(module):
     try:
 
         response = open_url(
-            api_base_url + end_point,
+            url,
             method="GET",
             headers=headers,
             validate_certs=validate_certs,
@@ -232,8 +236,8 @@ def user_details(module):
                 msg=(
                     "Error while performing user_details."
                     "Please validate parameters provided."
-                    "\n*** end_point=%s%s\n ==> %s"
-                    % (api_base_url, end_point, to_text(http_exception))
+                    "\n*** end_point=%s\n ==> %s"
+                    % (url, to_text(http_exception))
                 ),
                 headers=headers,
                 status_code=http_exception.code,
@@ -244,8 +248,8 @@ def user_details(module):
         module.fail_json(
             msg=(
                 "Unknown error while performing user_details."
-                "\n*** end_point=%s%s\n%s"
-                % (api_base_url, end_point, to_text(unknown_exception))
+                "\n*** end_point=%s\n%s"
+                % (url, to_text(unknown_exception))
             ),
             headers=headers,
             status_code=-1,
@@ -357,11 +361,12 @@ def user_add_or_update(module, HTTPMethod, existing_info):
 
     if proceed:
         logging.info("Proceeding to either update or create")
+        url = construct_url(api_base_url, end_point)
         try:
 
             # execute REST action
             response = open_url(
-                api_base_url + end_point,
+                url,
                 method=HTTPMethod,
                 headers=headers,
                 data=json.dumps(payload),
@@ -379,8 +384,8 @@ def user_add_or_update(module, HTTPMethod, existing_info):
                 msg=(
                     "Error while performing user_add_or_update."
                     "Please validate parameters provided."
-                    "\n*** end_point=%s%s\n ==> %s"
-                    % (api_base_url, end_point, to_text(http_exception))
+                    "\n*** end_point=%s\n ==> %s"
+                    % (url, to_text(http_exception))
                 ),
                 payload=payload,
                 headers=headers,
@@ -391,8 +396,8 @@ def user_add_or_update(module, HTTPMethod, existing_info):
             module.fail_json(
                 msg=(
                     "Unknown error while performing user_add_or_update."
-                    "\n*** end_point=%s%s\n%s"
-                    % (api_base_url, end_point, to_text(unknown_exception))
+                    "\n*** end_point=%s\n%s"
+                    % (url, to_text(unknown_exception))
                 ),
                 payload=payload,
                 headers=headers,
@@ -417,12 +422,13 @@ def user_delete(module):
 
     headers = {"Content-Type": "application/json"}
     headers["Authorization"] = cyberark_session["token"]
+    url = construct_url(api_base_url, end_point)
 
     try:
 
         # execute REST action
         response = open_url(
-            api_base_url + end_point,
+            url,
             method="DELETE",
             headers=headers,
             validate_certs=validate_certs,
@@ -445,8 +451,8 @@ def user_delete(module):
                 msg=(
                     "Error while performing user_delete."
                     "Please validate parameters provided."
-                    "\n*** end_point=%s%s\n ==> %s"
-                    % (api_base_url, end_point, exception_text)
+                    "\n*** end_point=%s\n ==> %s"
+                    % (url, exception_text)
                 ),
                 headers=headers,
                 status_code=http_exception.code,
@@ -457,8 +463,8 @@ def user_delete(module):
         module.fail_json(
             msg=(
                 "Unknown error while performing user_delete."
-                "\n*** end_point=%s%s\n%s"
-                % (api_base_url, end_point, to_text(unknown_exception))
+                "\n*** end_point=%s\n%s"
+                % (url, to_text(unknown_exception))
             ),
             headers=headers,
             status_code=-1,
@@ -474,7 +480,7 @@ def resolve_group_name_to_id(module):
       "Content-Type": "application/json",
       "Authorization": cyberark_session["token"]
     }
-    url = "{}PasswordVault/api/UserGroups?filter=groupName%20eq{}".format(api_base_url, quote(group_name))
+    url = construct_url(api_base_url, "/PasswordVault/api/UserGroups?filter=groupName%20eq{}".format(quote(group_name)))
     try:
         response = open_url(
             url,
@@ -550,11 +556,12 @@ def user_add_to_group(module):
     if domain_name:
         payload["domain_name"] = domain_name
 
+    url = construct_url(api_base_url, end_point)
     try:
 
         # execute REST action
         response = open_url(
-            api_base_url + end_point,
+            url,
             method="POST",
             headers=headers,
             data=json.dumps(payload),
@@ -577,8 +584,8 @@ def user_add_to_group(module):
                 msg=(
                     "Error while performing user_add_to_group."
                     "Please validate parameters provided."
-                    "\n*** end_point=%s%s\n ==> %s"
-                    % (api_base_url, end_point, exception_text)
+                    "\n*** end_point=%s\n ==> %s"
+                    % (url, exception_text)
                 ),
                 payload=payload,
                 headers=headers,
@@ -590,8 +597,8 @@ def user_add_to_group(module):
         module.fail_json(
             msg=(
                 "Unknown error while performing user_add_to_group."
-                "\n*** end_point=%s%s\n%s"
-                % (api_base_url, end_point, to_text(unknown_exception))
+                "\n*** end_point=%s\n%s"
+                % (url, to_text(unknown_exception))
             ),
             payload=payload,
             headers=headers,

--- a/plugins/modules/cyberark_user.py
+++ b/plugins/modules/cyberark_user.py
@@ -580,7 +580,7 @@ def resolve_group_name_to_id(module):
         for group in groups['value']:
             if group['groupName'] == group_name:
                 if group_id == None:
-                    group_id == group['id']
+                    group_id = group['id']
                 else:
                     module.fail_json(msg=("Found more than one group matching %s. Use vault_id instead" % (group_name)))
         # If we made it here we had 1 or 0 users, return them
@@ -638,6 +638,8 @@ def user_add_to_group(module):
     if group_name and not vault_id:
         # If we were given a group_name we need to lookup the vault_id
         vault_id = resolve_group_name_to_id(module)
+        if vault_id == None:
+            module.fail_json(msg="Unable to find a user group named %s, please create that before adding a user to it" % (group_name)))
 
     end_point = ("/PasswordVault/api/UserGroups/{0}/Members").format(vault_id)
 

--- a/plugins/modules/cyberark_user.py
+++ b/plugins/modules/cyberark_user.py
@@ -480,7 +480,7 @@ def resolve_group_name_to_id(module):
       "Content-Type": "application/json",
       "Authorization": cyberark_session["token"]
     }
-    url = construct_url(api_base_url, "/PasswordVault/api/UserGroups?filter=groupName%20eq{}".format(quote(group_name)))
+    url = construct_url(api_base_url, "/PasswordVault/api/UserGroups?search={}".format(quote(group_name)))
     try:
         response = open_url(
             url,
@@ -490,11 +490,11 @@ def resolve_group_name_to_id(module):
             timeout=module.params['timeout'],
         )
         groups = json.loads(response.read())
-        if len(groups) == 0:
+        if groups['count'] == 0:
             module.fail_json(msg=("Unable to find a group named %s" % (group_name)))
-        if len(groups) > 1:
+        if groups['count'] > 1:
             module.fail_json(msg=("Found more than one group named %s, please use vault_id parameter instead" % (group_name)))
-        return groups[0]['id']
+        return groups['value'][0]['id']
 
     except (HTTPError, httplib.HTTPException) as http_exception:
         module.fail_json(msg=(

--- a/plugins/modules/cyberark_user.py
+++ b/plugins/modules/cyberark_user.py
@@ -324,6 +324,8 @@ def user_add_or_update(module, HTTPMethod, existing_info):
         and module.params["user_type_name"] is not None
     ):
         payload["UserTypeName"] = module.params["user_type_name"]
+        # In API V2 the parameter is called userType, V2 ignores the UserTypeName
+        payload["userType"] = module.params["user_type_name"]
 
     if "disabled" in module.params and module.params["disabled"] is not None:
         payload["Disabled"] = module.params["disabled"]

--- a/plugins/modules/cyberark_user.py
+++ b/plugins/modules/cyberark_user.py
@@ -129,7 +129,7 @@ options:
         description:
             - The ID of the user group to add the user to
             - Prefered over group_name
-        type: str
+        type: int
 """
 
 EXAMPLES = r"""
@@ -549,7 +549,7 @@ def user_add_to_group(module):
         # If we were given a group_name we need to lookup the vault_id
         vault_id = resolve_group_name_to_id(module)
 
-    end_point = ("/PasswordVault/api/UserGroups/{0}/Members").format(quote(vault_id))
+    end_point = ("/PasswordVault/api/UserGroups/{0}/Members").format(vault_id)
 
     # payload = {"UserName": username}
     payload = {"memberId": member_id, "memberType": member_type}
@@ -628,7 +628,7 @@ def main():
             disabled=dict(type="bool"),
             location=dict(type="str"),
             group_name=dict(type="str"),
-            vault_id=dict(type="str"),
+            vault_id=dict(type="int"),
             member_type=dict(type="str"),
             domain_name=dict(type="str"),
             timeout=dict(type="float", default=10),

--- a/plugins/modules/cyberark_user.py
+++ b/plugins/modules/cyberark_user.py
@@ -615,7 +615,7 @@ def user_add_to_group(module):
     username = module.params["username"]
     group_name = module.params["group_name"]
     vault_id = module.params["vault_id"]
-    member_id = username
+    member_id = module.params["vault_user_id"]
     member_type = (
         "Vault"
         if module.params["member_type"] is None
@@ -639,7 +639,12 @@ def user_add_to_group(module):
         # If we were given a group_name we need to lookup the vault_id
         vault_id = resolve_group_name_to_id(module)
         if vault_id == None:
-            module.fail_json(msg="Unable to find a user group named %s, please create that before adding a user to it" % (group_name)))
+            module.fail_json(msg="Unable to find a user group named {}, please create that before adding a user to it".format(group_name))
+
+    if username and not member_id:
+        member_id = resolve_username_to_id(module)
+        if member_id == None:
+            module.fail_json(msg="Unable to find named {}, please check the user id".format(username))
 
     end_point = ("/PasswordVault/api/UserGroups/{0}/Members").format(vault_id)
 


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_
When attempting to use the code in this repo against a CyberArk instance several issues were encountered. This PR attempts to correct the issues we experienced. All changes are to the cybrerark_user module:
-- Added a timeout to be passed through to the http calls.
-- Added a vault_user_id option to make users act like groups for API v2.
-- Added vault_id parameter to the module documentation.
-- Added construct_url method to handle the '/' between the base url and the endpoint.
-- Added resolve_username_to_id and resolve_group_name_to_id methods. These methods will take an older parameter (like group_name) and resolve that to an ID. These resolutions will only be used if the corresponding vault_id/vault_user_id options are not set. This change makes the module backwards compatible.
-- Fixed user_delete function (it was using API V2 expecting a user id with the old username parameter)

- _How should the reviewer approach this PR, especially if manual tests are required?_
This PR was made with limited testing against a CyberArk instance, none of the tests in the tests folder were run. Please validate functionality.

- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]
Did not open issues against the repo for these, please let me know if you want issues tied to this PR.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update
- [X] There is no CHANGELOG in this repo

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests
- [X] This PR may require unit test changes but I do not have a way to test them. Please review and let me know if you require anything from a testing perspective.

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
- [X] This PR does not change the README content. There is content in the docs directory that could change but I am unsure if that doc is current since the README references the Ansible website directly.
