### PR TITLE
Update cyberark_authentication.py

### DIFF
--- a/plugins/modules/cyberark_authentication.py
+++ b/plugins/modules/cyberark_authentication.py
@@ -185,6 +185,7 @@ def processAuthentication(module):
 
         if use_ldap:
             end_point = "/PasswordVault/API/Auth/LDAP/Logon"
+            payload_dict = {"username": username, "password": password}
 
         elif use_radius:
             end_point = "/PasswordVault/API/Auth/radius/Logon"


### PR DESCRIPTION
Added the line 188, to send the payload with username and password.

The payload is empty when authenticating with LDAP, causing an error. When I added the payload, it authenticated as expected.

### Desired Outcome

There's a bug with the authentication using LDAP. The payload with the username and password is not being sent (empty), and causing an error.

### Implemented Changes

Is expected to receive a cyberark_session json file with the token and other parameters, but the execution fails because no payload is defined with the username and password for the authentication.

I added the line 188 in the cyberark_authentication.py file, to send the payload correctly. I tested, and it's working.

### Definition of Done
To solve the issue:
I just added the line 188:

payload_dict = {"username": username, "password": password}

#### Behavior

- After the insertion of the line 188, I received a cyberark_session json file with the token and other parameters, as expected.


