### PR TITLE
Replaced concurrentSessions by concurrentSession

### DIFF
--- a/plugins/modules/cyberark_authentication.py
+++ b/plugins/modules/cyberark_authentication.py
@@ -168,7 +168,7 @@ def processAuthentication(module):
     state = module.params["state"]
     cyberark_session = module.params["cyberark_session"]
 
-    concurrentSessions = module.params["concurrentSessions"]
+    concurrentSession = module.params["concurrentSession"]
 
     # if in check mode it will not perform password changes
     if module.check_mode and new_password is not None:
@@ -207,8 +207,8 @@ def processAuthentication(module):
         # if connection_number is not None:
         #     payload_dict["connectionNumber"] = connection_number
 
-        if concurrentSessions == True:
-            payload_dict["concurrentSessions"] = True
+        if concurrentSession == True:
+            payload_dict["concurrentSession"] = True
 
         payload = json.dumps(payload_dict)
 
@@ -323,7 +323,7 @@ def main():
         "use_windows_authentication": {"default": False, "type": "bool"},
         "use_ldap_authentication": {"default": False, "type": "bool"},
         "use_cyberark_authentication": {"default": False, "type": "bool"},
-        "concurrentSessions": {"default": False, "type": "bool"},
+        "concurrentSession": {"default": False, "type": "bool"},
         "connection_number": {"type": "int"},
         "state": {
             "type": "str",


### PR DESCRIPTION
As documented in Cyberark API v2 documentation the field is "concurrentSession" and not "concurrentSessions"

[https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/CyberArk%20Authentication%20-%20Logon_v10.htm?tocpath=Developer%7CREST%20APIs%7CAuthentication%7CLogon%7C_____1#Bodyparameters](cyberark doc)
### Desired Outcome

Allow concurrent sessions

### Implemented Changes

Replaced "concurrentSessions" by "concurrentSession"

### Connected Issue/Story

Resolves #[https://github.com/cyberark/ansible-security-automation-collection/issues/34]

CyberArk internal issue link: []()

### Definition of Done
Replace concurrentSessions by concurrentSession

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
