### PR TITLE
Added timeout option to authentication module

### DIFF
--- a/docs/cyberark_authentication.md
+++ b/docs/cyberark_authentication.md
@@ -44,6 +44,11 @@ options:
     cyberark_session:
         description:
             - Dictionary set by a CyberArk authentication containing the different values to perform actions on a logged-on CyberArk session.
+    timeout:
+        type: int
+        default: 10
+        description:
+            - Allows you set a timeout for when your authenticating to Cyberark
 ```
 ## Example Playbooks
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "cyberark"
 name: "pas"
-version: "1.0.15"
+version: "1.0.16"
 readme: README.md
 authors:
     - CyberArk Business Development (@cyberark-bizdev)

--- a/plugins/modules/cyberark_authentication.py
+++ b/plugins/modules/cyberark_authentication.py
@@ -92,6 +92,10 @@ options:
               different values to perform actions on a logged-on CyberArk
               session.
         type: dict
+    timeout:
+        description:
+            - Allows you set a timeout for when your authenticating to Cyberark
+        type: int
 """
 
 EXAMPLES = """
@@ -171,6 +175,8 @@ def processAuthentication(module):
 
     concurrentSession = module.params["concurrentSession"]
 
+    timeout = module.params["timeout"]
+
     # if in check mode it will not perform password changes
     if module.check_mode and new_password is not None:
         new_password = None
@@ -240,6 +246,7 @@ def processAuthentication(module):
             headers=headers,
             data=payload,
             validate_certs=validate_certs,
+            timeout=timeout,
         )
 
     except (HTTPError, HTTPException) as http_exception:
@@ -336,6 +343,7 @@ def main():
             "default": "present",
         },
         "cyberark_session": {"type": "dict"},
+        "timeout": {"default": 10, "type": "int"},
     }
 
     # cyberark and radius -> mutually_exclusive is cyberark and ldap


### PR DESCRIPTION
### Desired Outcome

We noticed now we have turned on two factor we have a problem with the module timing out before we have pressed the push notification.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

Adding a timeout option to the authentication module, tested it using a local copy of the module with my Cyberark system

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]  #47

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
