### PR TITLE
1.0.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,105 @@
+# README FIRST
+# 1. If you don't have unit tests, remove that section.
+# 2. If your collection depends on other collections ensure they are installed,
+#    add them to the "test-deps" input.
+# 3. For the comprehensive list of the inputs supported by the
+#    ansible-community/ansible-test-gh-action GitHub Action, see
+#    https://github.com/marketplace/actions/ansible-test.
+# 4. If you want to prevent merging PRs that do not pass all tests,
+#    make sure to add the "check" job to your repository branch
+#    protection once this workflow is added.
+#    It is also possible to tweak which jobs are allowed to fail. See
+#    https://github.com/marketplace/actions/alls-green#gotchas for more detail.
+# 5. If you need help please ask in #ansible-community on the Libera.chat IRC
+#    network.
+
+name: CI
+on:
+  # Run CI against all pushes (direct commits, also merged PRs), Pull Requests
+  push:
+    branches:
+      - main
+      - master
+      - stable-*
+  pull_request:
+  # Run CI once per day (at 06:00 UTC)
+  # This ensures that even if there haven't been commits that we are still
+  # testing against latest version of ansible-test for each ansible-core
+  # version
+  schedule:
+    - cron: '0 6 * * *'
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.pull_request.number || github.sha
+    }}
+  cancel-in-progress: true
+
+jobs:
+
+###
+# Sanity tests (REQUIRED)
+#
+# https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
+
+  sanity:
+    name: Sanity (Ⓐ${{ matrix.ansible }})
+    strategy:
+      matrix:
+        ansible:
+          # It's important that Sanity is tested against all stable-X.Y branches
+          # Testing against `devel` may fail as new tests are added.
+          # An alternative to `devel` is the `milestone` branch with
+          # gets synchronized with `devel` every few weeks and therefore
+          # tends to be a more stable target. Be aware that it is not updated
+          # around creation of a new stable branch, this might cause a problem
+          # that two different versions of ansible-test use the same sanity test
+          # ignore.txt file.
+          - stable-2.9 # Only if your collection supports Ansible 2.9
+          - stable-2.10 # Only if your collection supports ansible-base 2.10
+          - stable-2.11
+          - stable-2.12
+          - stable-2.13
+          - stable-2.14
+          - devel
+        # - milestone
+    # Ansible-test on various stable branches does not yet work well with cgroups v2.
+    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
+    # image for these stable branches. The list of branches where this is necessary will
+    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
+    # for the latest list.
+    runs-on: >-
+      ${{ contains(fromJson(
+          '["stable-2.9", "stable-2.10", "stable-2.11"]'
+      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    steps:
+      # Run sanity tests inside a Docker container.
+      # The docker container has all the pinned dependencies that are
+      # required and all Python versions Ansible supports.
+      - name: Perform sanity testing
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          ansible-core-version: ${{ matrix.ansible }}
+          testing-type: sanity
+          # OPTIONAL If your sanity tests require code
+          # from other collections, install them like this
+          # test-deps: >-
+          #   ansible.netcommon
+          #   ansible.utils
+
+  check:  # This job does nothing and is only used for the branch protection
+          # or multi-stage CI jobs, like making sure that all tests pass before
+          # a publishing job is started.
+    if: always()
+
+    needs:
+      - sanity
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ None.
 - Using AAM Central Credential Provider (CCP), to securely retreive secrets and account properties from EPV to be registered for use in playbooks<br>
 [Playbooks and Module Info](https://github.com/cyberark/ansible-security-automation-collection/blob/master/docs/cyberark_credential.md)
 
+## Roles
+
+#### aimprovider
+
+- Install agent-based Credential Provider (AIM) on Linux hosts
+[Playbooks and Module Info](https://github.com/cyberark/ansible-security-automation-collection/blob/master/docs/aimprovider.md)
+
 #### Python3
 
 - The modules will work with either python2 or python3.

--- a/docs/aimprovider.md
+++ b/docs/aimprovider.md
@@ -1,0 +1,91 @@
+cyberark.pas.aimprovider
+====================
+
+Role to install/uninstall CyberArk's AIM Credential Provider.
+
+Requirements
+------------
+
+- CyberArk Privileged Account Security Web Services SDK.
+- `cyberark.pas` Collection from Ansible Galaxy or Automation Hub
+
+Role Variables
+--------------
+```
+# CyberArk's Privileged Account Security Web Services SDK api base URL (example: https://components.cyberark.local)
+rest_api_url: ""
+
+# Whether to validate certificates for REST api calls. If false, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+validate_certs: true
+
+# Zip file with distribution of AIM Provider (example: /tmp/binaries/RHELinux x64-Rls-v9.8.zip); this file is located in the Ansible server, and it will be copied to the Ansible nodes. It should point to the current version of AIM distribution to be used when delivering to the nodes in a central folder within the Ansible server.
+zip_file_name: ""
+
+# Folder name within the ZIP file that will be used. By default, it's taken from zip file name, for example: "RHELinux x64"
+folder_name: '{{zip_file_name.split("/")[-1].split("-Rls")[0]}}'
+
+# CyberArk location for App Provider user to be created
+app_provider_user_location: "\\Applications"
+
+# CyberArk Vault Address
+vault_address: ""
+
+# Whether to use shared logon authentication. If true, it will use the "Shared Logon Authentication" as described in the CyberArk's document "Privileged Account Security Web Services SDK Implementation Guide"
+use_shared_logon_authentication: false
+
+# State - can be "present"/"absent" for install/uninstall.
+state: "present"
+```
+
+
+Additionally:
+- **app_provider_user_group**: The name of the group the Provider user will be added to.
+
+Dependencies
+------------
+
+None.
+
+
+Example Playbook
+----------------
+
+1) Install CyberArk AIM Provider.
+
+```
+---
+- hosts: all
+
+  roles:
+
+    - role: cyberark.pas.aimprovider
+      api_base_url: "https://components.cyberark.local"
+      validate_certs: false
+      zip_file_name: "/tmp/binaries/RHELinux x64-Rls-v9.8.zip"
+      vault_address: "10.0.1.10"
+      use_shared_logon_authentication: true
+```
+
+2) Uninstall CyberArk AIM Provider.
+```
+---
+- hosts: all
+
+  roles:
+
+    - role: cyberark.pas.aimprovider
+      api_base_url: "https://components.cyberark.local"
+      use_shared_logon_authentication: true
+      state: "absent"
+      validate_certs: false
+```
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+- Edward Nunez (edward.nunez@cyberark.com)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,6 +5,7 @@ readme: README.md
 authors:
     - CyberArk Business Development (@cyberark-bizdev)
     - Edward Nunez (@enunez-cyberark)
+    - Joe Garcia (@infamousjoeg)
 description: "This is a Collection of the CyberArk Ansible Security Automation toolkit."
 license: "MIT"
 tags:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "cyberark"
 name: "pas"
-version: "1.0.16"
+version: "1.0.17"
 readme: README.md
 authors:
     - CyberArk Business Development (@cyberark-bizdev)

--- a/plugins/modules/cyberark_account.py
+++ b/plugins/modules/cyberark_account.py
@@ -22,7 +22,7 @@ author:
     - CyberArk BizDev (@cyberark-bizdev)
     - Edward Nunez (@enunez-cyberark)
     - James Stutes (@jimmyjamcabd)
-version_added: 2.4
+version_added: '1.0.0'
 description:
     - Creates a URI for adding, deleting, modifying a privileged credential
       within the Cyberark Vault.  The request uses the Privileged Account
@@ -35,7 +35,7 @@ options:
             - Assert the desired state of the account C(present) to creat or
               update and account object. Set to C(absent) for deletion of an
               account object.
-        required: true
+        required: false
         default: present
         choices: [present, absent]
         type: str
@@ -43,7 +43,7 @@ options:
         description:
             - Parameter used to define the level of troubleshooting output to
               the C(logging_file) value.
-        required: true
+        required: false
         choices: [NOTSET, DEBUG, INFO]
         type: str
     logging_file:
@@ -57,7 +57,7 @@ options:
             - A string containing the base URL of the server hosting CyberArk's
               Privileged Account Security Web Services SDK.
             - Example U(https://<IIS_Server_Ip>/PasswordVault/api/)
-        required: true
+        required: false
         type: str
     validate_certs:
         description:
@@ -71,7 +71,7 @@ options:
         description:
             - Dictionary set by a CyberArk authentication containing the
               different values to perform actions on a logged-on CyberArk
-              session, please see M(cyberark_authentication) module for an
+              session, please see M(cyberark.pas.cyberark_authentication) module for an
               example of cyberark_session.
         required: true
         type: dict
@@ -337,7 +337,7 @@ result:
                   the credential.
             returned: successful addition and modification
             type: complex
-            sample:
+            contains:
                 automaticManagementEnabled:
                     description:
                         - Parameter that indicates whether the CPM will manage
@@ -353,6 +353,7 @@ result:
                     sample: "1567824520"
                 manualManagementReason:
                     description:
+                        - Reason for disabling automatic management of the account
                     returned: if C(automaticManagementEnabled) is set to false
                     type: str
                     sample: This is a static account
@@ -1223,7 +1224,10 @@ def main():
             "required": False,
             "type": "dict",
             "options": {
-                "automatic_management_enabled": {"type": "bool"},
+                "automatic_management_enabled": {
+                    "type": "bool",
+                    "default": False,
+                },
                 "manual_management_reason": {"type": "str"},
                 "management_action": {
                     "type": "str",
@@ -1236,6 +1240,7 @@ def main():
                     "default": "always",
                 },
             },
+            "no_log": False,
         },
         "remote_machines_access": {
             "required": False,

--- a/plugins/modules/cyberark_authentication.py
+++ b/plugins/modules/cyberark_authentication.py
@@ -18,10 +18,9 @@ DOCUMENTATION = """
 module: cyberark_authentication
 short_description: CyberArk Authentication using PAS Web Services SDK.
 author:
-    - Edward Nunez (@enunez-cyberark) CyberArk BizDev
+    - Edward Nunez (@enunez-cyberark)
     - Cyberark Bizdev (@cyberark-bizdev)
-    - Edgar Mota
-version_added: 2.4
+version_added: '1.0.0'
 description:
     - Authenticates to CyberArk Vault using Privileged Account Security
       Web Services SDK and creates a session fact that can be used by other
@@ -86,6 +85,11 @@ options:
         description:
             - To support multiple connections for same user specify
             - different value for this parameter.
+    concurrentSession:
+        type: bool
+        default: False
+        description:
+            - Whether or not to allow concurrent sessions for the same user.
     cyberark_session:
         description:
             - Dictionary set by a CyberArk authentication containing the
@@ -95,6 +99,7 @@ options:
     timeout:
         description:
             - Allows you set a timeout for when your authenticating to Cyberark
+        default: 10
         type: int
 """
 

--- a/plugins/modules/cyberark_credential.py
+++ b/plugins/modules/cyberark_credential.py
@@ -22,7 +22,7 @@ author:
     - CyberArk BizDev (@cyberark-bizdev)
     - Erasmo Acosta (@erasmix)
     - James Stutes (@JimmyJamCABD)
-version_added: 2.4
+version_added: '1.0.0'
 description:
     - Creates a URI for retrieving a credential from a password object stored
       in the Cyberark Vault.  The request uses the Privileged Account Security
@@ -185,7 +185,7 @@ result:
             returned: if assigned to a policy
         Safe:
             description: The safe where the queried credential is stored
-            type: string
+            type: str
             returned: always
         Username:
             description: The username of the credential being queried
@@ -323,7 +323,7 @@ def main():
         },
         "validate_certs": {"type": "bool", "default": True},
         "client_cert": {"type": "str", "required": False},
-        "client_key": {"type": "str", "required": False},
+        "client_key": {"type": "str", "required": False, "no_log": True},
     }
 
     module = AnsibleModule(argument_spec=fields, supports_check_mode=True)

--- a/plugins/modules/cyberark_user.py
+++ b/plugins/modules/cyberark_user.py
@@ -24,7 +24,7 @@ author:
   - Cyberark Bizdev (@cyberark-bizdev)
   - Erasmo Acosta (@erasmix)
   - James Stutes (@jimmyjamcabd)
-version_added: 2.4
+version_added: '1.0.0'
 description:
     - CyberArk User Management using PAS Web Services SDK,
       It currently supports the following actions Get User Details, Add User,
@@ -48,7 +48,7 @@ options:
         description:
             - Parameter used to define the level of troubleshooting output to
               the C(logging_file) value.
-        required: true
+        required: false
         choices: [NOTSET, DEBUG, INFO]
         default: NOTSET
         type: str
@@ -62,7 +62,7 @@ options:
         description:
             - Dictionary set by a CyberArk authentication containing the
               different values to perform actions on a logged-on CyberArk
-              session, please see M(cyberark_authentication) module for an
+              session, please see M(cyberark.pas.cyberark_authentication) module for an
               example of cyberark_session.
         type: dict
         required: True
@@ -95,6 +95,14 @@ options:
               next logon.
         type: bool
         default: no
+    domain_name:
+        description:
+            - The name of the user domain.
+        type: str
+    member_type:
+        description:
+            - The type of member.
+        type: str
     expiry_date:
         description:
             - The date and time when the user account will expire and become
@@ -137,6 +145,7 @@ options:
             - Options can include AddSafes and AuditUsers
             - The default provides backwards compatability with older versions of the collection
         type: list
+        elements: str
         default:
           - AddSafes
           - AuditUsers
@@ -719,17 +728,17 @@ def main():
             email=dict(type="str"),
             first_name=dict(type="str"),
             last_name=dict(type="str"),
-            change_password_on_the_next_logon=dict(type="bool"),
+            change_password_on_the_next_logon=dict(type="bool", default=False),
             expiry_date=dict(type="str"),
             user_type_name=dict(type="str"),
-            disabled=dict(type="bool"),
+            disabled=dict(type="bool", default=False),
             location=dict(type="str"),
             group_name=dict(type="str"),
             vault_id=dict(type="int"),
             member_type=dict(type="str"),
             domain_name=dict(type="str"),
             timeout=dict(type="float", default=10),
-            authorization=dict(type="list", required=False, default=['AddSafes', 'AuditUsers']),
+            authorization=dict(type="list", elements="str", required=False, default=['AddSafes', 'AuditUsers']),
         )
     )
 

--- a/roles/aimprovider/defaults/main.yml
+++ b/roles/aimprovider/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+
+# Default values for possible input parameters
+
+# CyberArk's Privileged Account Security Web Services SDK api base URL
+rest_api_url: ""
+
+# Whether to validate certificates for REST api calls
+validate_certs: true
+
+# Zip file with distribution of AIM Provider
+zip_file_name: ""
+
+# Folder name within the ZIP file that will be used by default is taken from zip file name.
+folder_name: '{{zip_file_name.split("/")[-1].split("-Rls")[0]}}'
+
+# CyberArk location for App Provider user to be created
+app_provider_user_location: "\\Applications"
+
+# CyberArk Vault Address
+vault_address: ""
+
+# Whether to use shared logon authentication
+use_shared_logon_authentication: false
+
+# State - the state of the provider: present mean installing the provide and Absent means uninstalling
+state: "present"

--- a/roles/aimprovider/tasks/installAIMProvider.yml
+++ b/roles/aimprovider/tasks/installAIMProvider.yml
@@ -1,0 +1,152 @@
+---
+- name: Validating Role Parameters
+  assert:
+    that:
+      - zip_file_name != ''
+      - vault_address != ''
+      - api_base_url != ''
+      - folder_name != ''
+      - app_provider_user_location != ''
+      - state == "present"
+      - (not use_shared_logon_authentication|default(false) and password_object is defined) or
+        (use_shared_logon_authentication|default(false) and password_object is not defined)
+
+
+- debug: msg="Installation params => zip_file_name = {{zip_file_name}}  folder_name={{folder_name}}"
+
+- block:
+
+  - name: Copy provider zip to target and unzip
+    unarchive: src="{{zip_file_name}}" dest=/tmp
+
+  - name: Rename aimparms and copy to var/tmp
+    command: cp "/tmp/{{folder_name}}/aimparms.sample" /var/tmp/aimparms
+
+  - name: Replace parameters" in /var/tmp/aimparms
+    replace:
+      dest: /var/tmp/aimparms
+      regexp: "{{item.regexp}}"
+      replace: "{{item.replace}}"
+    with_items:
+      - {regexp: '^AcceptCyberArkEULA=.*$', replace: 'AcceptCyberArkEULA=Yes'}
+      - {regexp: '^LicensedProducts=.*$', replace: 'LicensedProducts=AIM'}
+      - {regexp: '^.?CreateVaultEnvironment=.*$', replace: 'CreateVaultEnvironment=no'}
+      - {regexp: '^VaultFilePath=.*$', replace: 'VaultFilePath=/tmp/{{folder_name}}/Vault.ini'}
+
+
+  - name: Change Vault.ini to the right address
+    replace:
+      dest: "/tmp/{{folder_name}}/Vault.ini"
+      regexp: '^ADDRESS=.*$'
+      replace: 'ADDRESS={{vault_address}}'
+
+  - name: Change permission on createcredfile
+    file:
+      path: "/tmp/{{folder_name}}/CreateCredFile"
+      mode: 0755
+
+  - find:
+      paths: "/tmp/{{folder_name}}"
+      patterns: "CARKaim-*.rpm"
+    register: aimrpm
+
+  # debug: msg="{{aimrpm.files[0].path}}"
+
+  - name: Install Provider
+    package: name='{{aimrpm.files[0].path}}' state=present
+
+  - name: Verify status of service after installing Provider
+    command: service aimprv status
+    register: command_result
+    ignore_errors: yes
+    args:
+      warn: false
+
+  # debug: msg="status of service RC={{command_result.rc}}"
+
+  - name: Logon to CyberArk Vault using PAS Web Services SDK - use_shared_logon_authentication
+    cyberark.pas.cyberark_authentication:
+      api_base_url: "{{ api_base_url }}"
+      use_shared_logon_authentication: true
+      validate_certs: "{{ validate_certs }}"
+    changed_when: false
+    when: (command_result.rc != 0 and use_shared_logon_authentication|default(false))
+
+  - name: Logon to CyberArk Vault using PAS Web Services SDK - Not use_shared_logon_authentication
+    cyberark.pas.cyberark_authentication:
+      api_base_url: "{{ api_base_url }}"
+      username: "{{ password_object.password }}"
+      password: "{{ password_object.passprops.username }}"
+      validate_certs: "{{ validate_certs }}"
+    changed_when: false
+    when: (command_result.rc != 0 and not use_shared_logon_authentication|default(false))
+
+  # name: Debug message
+  #  debug:
+  #    msg: "{{ cyberark_session.token }}"
+  #  when: (command_result.rc != 0)
+
+  - name: Create provider user
+    cyberark.pas.cyberark_user:
+      username: "Prov_{{ ansible_hostname }}"
+      initial_password: "Cyberark1"
+      user_type_name: "AppProvider"
+      location: "{{ app_provider_user_location }}"
+      group_name: "{{ app_provider_user_group }}"
+      change_password_on_the_next_logon: false
+      state: present
+      cyberark_session: "{{ cyberark_session }}"
+    register: cyberarkaction
+    when: (command_result.rc != 0)
+
+  # debug:
+  #    msg: "USERCREATED => {{cyberarkaction}}"
+  #  when: (command_result.rc != 0 and cyberarkaction.status_code == 201)
+
+  - name: Reset provider user credential
+    cyberark.pas.cyberark_user:
+      username: "Prov_{{ ansible_hostname }}"
+      new_password: "Cyberark1"
+      disabled: false
+      state: present
+      cyberark_session: "{{ cyberark_session }}"
+    register: cyberarkaction
+    when: (command_result.rc != 0 and cyberarkaction.status_code == 200)
+
+  - name: Logoff from CyberArk Vault
+    cyberark.pas.cyberark_authentication:
+      state: absent
+      cyberark_session: "{{ cyberark_session }}"
+    changed_when: false
+    when: (command_result.rc != 0)
+
+  - name: Create Provider Initial Cred File
+    command: /opt/CARKaim/bin/createcredfile /etc/opt/CARKaim/vault/appprovideruser.cred Password -Username Prov_{{ ansible_hostname }} -Password Cyberark1
+    when: (command_result.rc != 0)
+
+  - name: Set vault.ini Into Place
+    command: cp "/tmp/{{folder_name}}/Vault.ini" /etc/opt/CARKaim/vault/vault.ini
+
+  - name: Start Provider Service
+    service: name=aimprv state=started
+    when: (command_result.rc != 0)
+
+  - name: Remove /tmp/{{folder_name}}
+    file:
+      path: '/tmp/{{folder_name}}'
+      state: absent
+
+  - name: Remove /var/tmp/aimparms
+    file:
+      path: '/var/tmp/aimparms'
+      state: absent
+
+  rescue:
+
+    - name: Remove /tmp/{{folder_name}}
+      file:
+        path: '/tmp/{{folder_name}}'
+        state: absent
+
+    - fail:
+        msg: "AIM Credential Provider Installation failed!"

--- a/roles/aimprovider/tasks/main.yml
+++ b/roles/aimprovider/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Validating Role Parameters
+  assert:
+    that:
+      - api_base_url != ''
+      - state in ["present", "absent"]
+      - (not use_shared_logon_authentication|default(false) and password_object is defined) or
+        (use_shared_logon_authentication|default(false) and password_object is not defined)
+
+- name: Verify status of aimprv service initially
+  command: service aimprv status
+  register: service_already_running
+  ignore_errors: yes
+  changed_when: false
+  args:
+    warn: false
+
+- debug: msg="status of service RC={{service_already_running.rc}}"
+
+- import_tasks: installAIMProvider.yml
+  when: (state == "present" and service_already_running.rc != 0)
+
+- import_tasks: uninstallAIMProvider.yml
+  when: (state == "absent" and service_already_running.rc == 0)

--- a/roles/aimprovider/tasks/uninstallAIMProvider.yml
+++ b/roles/aimprovider/tasks/uninstallAIMProvider.yml
@@ -1,0 +1,61 @@
+---
+- block:
+
+  - name: Uninstall Provider
+    package: name='CARKaim' state=absent
+
+  - name: Logon to CyberArk Vault using PAS Web Services SDK - use_shared_logon_authentication
+    cyberark.pas.cyberark_authentication:
+      api_base_url: "{{ api_base_url }}"
+      use_shared_logon_authentication: true
+      validate_certs: "{{ validate_certs }}"
+    when: (use_shared_logon_authentication)
+
+  - name: Logon to CyberArk Vault using PAS Web Services SDK - Not use_shared_logon_authentication
+    cyberark.pas.cyberark_authentication:
+      api_base_url: "{{ api_base_url }}"
+      username: "{{ password_object.password }}"
+      password: "{{ password_object.passprops.username }}"
+      validate_certs: "{{ validate_certs }}"
+    changed_when: false
+    when: (not use_shared_logon_authentication)
+
+  # name: Debug message
+  #  debug:
+  #    msg: "{{ cyberark_session }}"
+  #  when: (cyberark_session.token is defined)
+
+  - name: Remove Provider User
+    cyberark.pas.cyberark_user:
+      username: "Prov_{{ansible_hostname}}"
+      state: absent
+      cyberark_session: "{{ cyberark_session }}"
+    register: cyberarkaction
+    ignore_errors: yes
+    when: (cyberark_session.token is defined)
+
+  # debug:
+  #    msg: "USERDETAILS => {{cyberarkaction}}"
+  #  when: (cyberarkaction.status_code == 200)
+
+  - name: Logoff from CyberArk Vault
+    cyberark.pas.cyberark_authentication:
+      state: absent
+      cyberark_session: "{{ cyberark_session }}"
+    changed_when: false
+    when: (cyberark_session.token is defined)
+
+  - name: Remove /etc/opt/CARKaim
+    file:
+      path: '/etc/opt/CARKaim'
+      state: absent
+
+  - name: Remove /var/opt/CARKaim
+    file:
+      path: '/var/opt/CARKaim'
+      state: absent
+
+  rescue:
+
+    - fail:
+        msg: "AIM Credential Provider Uninstall failed!"


### PR DESCRIPTION
### Desired Outcome

Release version 1.0.17 of the Ansible collection cyberark.pas.

### Implemented Changes

- Add sanity tests per Ansible Galaxy standards
- Add [aimprovider](https://github.com/cyberark/ansible-aim-provider) role

### Connected Issue/Story

Resolves #44 #50 

CyberArk internal issue ID: n/a

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [X] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes
