### PR TITLE
Standardize on true/false for all booleans in docs

### DIFF
--- a/docs/cyberark_account.md
+++ b/docs/cyberark_account.md
@@ -174,7 +174,7 @@ options:
                 automatic_management_enabled:
                     description:
                         - Parameter that indicates whether the CPM will manage the password or not
-                    default: True
+                    default: true
                     type: bool
                 manual_management_reason:
                     description:
@@ -232,7 +232,7 @@ options:
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark.pas.cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 

--- a/docs/cyberark_authentication.md
+++ b/docs/cyberark_authentication.md
@@ -26,19 +26,19 @@ options:
             - A string containing the base URL of the server hosting CyberArk's Privileged Account Security Web Services SDK.
     validate_certs:
         type: bool
-        default: 'yes'
+        default: 'true'
         description:
             - If C(false), SSL certificates will not be validated.  This should only
               set to C(false) used on personally controlled sites using self-signed
               certificates.
     use_shared_logon_authentication:
         type: bool
-        default: 'no'
+        default: 'false'
         description:
             - Whether or not Shared Logon Authentication will be used.
     use_radius_authentication:
         type: bool
-        default: 'no'
+        default: 'false'
         description:
             - Whether or not users will be authenticated via a RADIUS server. Valid values are true/false.
     cyberark_session:
@@ -77,7 +77,7 @@ In addition to SSL, use Client Authentication to authenticate Ansible using a cl
 - name: Logon to CyberArk Vault using PAS Web Services SDK - use_shared_logon_authentication
   cyberark_authentication:
     api_base_url: "{{ web_services_base_url }}"
-    use_shared_logon_authentication: yes
+    use_shared_logon_authentication: true
 ```
 
 **CyberArk Authentication**<br/>
@@ -91,7 +91,7 @@ Users can authenticate using **CyberArk**, **LDAP** or **RADIUS** authentication
     api_base_url: "{{ web_services_base_url }}"
     username: "{{ password_object.password }}"
     password: "{{ password_object.passprops.username }}"
-    use_shared_logon_authentication: no
+    use_shared_logon_authentication: false
 ```
 **Logoff**<br/>
 This method logs off the user and removes the Vault session.

--- a/docs/cyberark_credential.md
+++ b/docs/cyberark_credential.md
@@ -110,14 +110,14 @@ options:
 - name: credential retrieval advanced
   cyberark_credential:
     api_base_url: "https://components.cyberark.local"
-    validate_certs: yes
+    validate_certs: true
     client_cert: /etc/pki/ca-trust/source/client.pem
     client_key: /etc/pki/ca-trust/source/priv-key.pem
     app_id: "TestID"
     query: "Safe=test;UserName=admin"
     connection_timeout: 60
     query_format: Exact
-    fail_request_on_password_change: True
+    fail_request_on_password_change: true
     reason: "requesting credential for Ansible deployment"
   register: result
   

--- a/docs/cyberark_user.md
+++ b/docs/cyberark_user.md
@@ -27,7 +27,7 @@ options:
         description:
             - The name of the user who will be queried (for details), added, updated or deleted.
         type: str
-        required: True
+        required: true
     state:
         description:
             - Specifies the state needed for the user present for create user, absent for delete user.
@@ -39,7 +39,7 @@ options:
             - Dictionary set by a CyberArk authentication containing the different values to perform actions on a logged-on CyberArk session,
               please see M(cyberark_authentication) module for an example of cyberark_session.
         type: dict
-        required: True
+        required: true
     initial_password:
         description:
             - The password that the new user will use to log on the first time.
@@ -66,7 +66,7 @@ options:
         description:
             - Whether or not the user must change their password in their next logon.
         type: bool
-        default: no
+        default: false
     expiry_date:
         description:
             - The date and time when the user account will expire and become disabled.
@@ -80,7 +80,7 @@ options:
         description:
             - Whether or not the user will be disabled.
         type: bool
-        default: no
+        default: false
     location:
         description:
             - The Vault Location for the user.
@@ -98,7 +98,7 @@ This playbook will check if username `admin` exists, if it does not, it will pro
 - name: Logon to CyberArk Vault using PAS Web Services SDK
   cyberark_authentication:
     api_base_url: https://components.cyberark.local
-    use_shared_logon_authentication: yes
+    use_shared_logon_authentication: true
 
 - name: Create user, add to Group
   cyberark_user:
@@ -108,7 +108,7 @@ This playbook will check if username `admin` exists, if it does not, it will pro
     email: "cyber.admin@ansibledev.com"
     initial_password: PA$$Word123
     user_type_name: EPVUser
-    change_password_on_the_next_logon: yes
+    change_password_on_the_next_logon: true
     group_name: Auditors
     state: present
     cyberark_session: '{{ cyberark_session }}'
@@ -126,7 +126,7 @@ This playbook will identify the user and delete it from the CyberArk Vault based
 - name: Logon to CyberArk Vault using PAS Web Services SDK - use_shared_logon_authentication
   cyberark_authentication:
     api_base_url: "{{ web_services_base_url }}"
-    use_shared_logon_authentication: yes
+    use_shared_logon_authentication: true
 
 - name: Removing a CyberArk User
   cyberark_user:
@@ -147,7 +147,7 @@ This playbook is an example of disabling a user based on the `disabled: true` va
     api_base_url: "{{ web_services_base_url }}"
     username: "{{ password_object.password }}"
     password: "{{ password_object.passprops.username }}"
-    use_shared_logon_authentication: no
+    use_shared_logon_authentication: false
     
 - name: Disabling a CyberArk User
   cyberark_user:

--- a/plugins/modules/cyberark_account.py
+++ b/plugins/modules/cyberark_account.py
@@ -138,7 +138,7 @@ options:
                 description:
                     - Parameter that indicates whether the CPM will manage
                         the password or not.
-                default: False
+                default: false
                 type: bool
             manual_management_reason:
                 description:
@@ -209,7 +209,7 @@ EXAMPLES = """
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 

--- a/plugins/modules/cyberark_authentication.py
+++ b/plugins/modules/cyberark_authentication.py
@@ -54,29 +54,29 @@ options:
         type: str
     validate_certs:
         type: bool
-        default: 'yes'
+        default: 'true'
         description:
             - If C(false), SSL certificates will not be validated.  This
               should only set to C(false) used on personally controlled
               sites using self-signed certificates.
     use_ldap_authentication:
         type: bool
-        default: 'no'
+        default: 'false'
         description:
             - Whether or not LDAP will be used.
     use_windows_authentication:
         type: bool
-        default: 'no'
+        default: 'false'
         description:
             - Whether or not Windows will be used.
     use_cyberark_authentication:
         type: bool
-        default: 'no'
+        default: 'false'
         description:
             - Whether or not LDAP will be used.
     use_radius_authentication:
         type: bool
-        default: 'no'
+        default: 'false'
         description:
             - Whether or not users will be authenticated via a RADIUS
               server. Valid values are true/false.
@@ -87,7 +87,7 @@ options:
             - different value for this parameter.
     concurrentSession:
         type: bool
-        default: False
+        default: false
         description:
             - Whether or not to allow concurrent sessions for the same user.
     cyberark_session:
@@ -107,14 +107,14 @@ EXAMPLES = """
 - name: Logon - use_shared_logon_authentication
   cyberark_authentication:
     api_base_url: "{{ web_services_base_url }}"
-    use_shared_logon_authentication: yes
+    use_shared_logon_authentication: true
 
 - name: Logon - Not use_shared_logon_authentication
   cyberark_authentication:
     api_base_url: "{{ web_services_base_url }}"
     username: "{{ password_object.password }}"
     password: "{{ password_object.passprops.username }}"
-    use_shared_logon_authentication: no
+    use_shared_logon_authentication: false
 
 - name: Logoff from CyberArk Vault
   cyberark_authentication:

--- a/plugins/modules/cyberark_credential.py
+++ b/plugins/modules/cyberark_credential.py
@@ -112,14 +112,14 @@ EXAMPLES = """
     - name: credential retrieval advanced
       cyberark_credential:
         api_base_url: "https://components.cyberark.local"
-        validate_certs: yes
+        validate_certs: true
         client_cert: /etc/pki/ca-trust/source/client.pem
         client_key: /etc/pki/ca-trust/source/priv-key.pem
         app_id: "TestID"
         query: "Safe=test;UserName=admin"
         connection_timeout: 60
         query_format: Exact
-        fail_request_on_password_change: True
+        fail_request_on_password_change: true
         reason: "requesting credential for Ansible deployment"
       register: result
 

--- a/plugins/modules/cyberark_user.py
+++ b/plugins/modules/cyberark_user.py
@@ -36,7 +36,7 @@ options:
             - The name of the user who will be queried (for details), added,
               updated or deleted.
         type: str
-        required: True
+        required: true
     state:
         description:
             - Specifies the state needed for the user present for create user,
@@ -65,7 +65,7 @@ options:
               session, please see M(cyberark.pas.cyberark_authentication) module for an
               example of cyberark_session.
         type: dict
-        required: True
+        required: true
     initial_password:
         description:
             - The password that the new user will use to log on the first time.
@@ -94,7 +94,7 @@ options:
             - Whether or not the user must change their password in their
               next logon.
         type: bool
-        default: no
+        default: false
     domain_name:
         description:
             - The name of the user domain.
@@ -117,7 +117,7 @@ options:
         description:
             - Whether or not the user will be disabled.
         type: bool
-        default: no
+        default: false
     location:
         description:
             - The Vault Location for the user.
@@ -155,14 +155,14 @@ EXAMPLES = r"""
 - name: Logon to CyberArk Vault using PAS Web Services SDK
   cyberark_authentication:
     api_base_url: https://components.cyberark.local
-    use_shared_logon_authentication: yes
+    use_shared_logon_authentication: true
 
 - name: Create user & immediately add it to a group
   cyberark_user:
     username: username
     initial_password: password
     user_type_name: EPVUser
-    change_password_on_the_next_logon: no
+    change_password_on_the_next_logon: false
     group_name: GroupOfUser
     state: present
     cyberark_session: '{{ cyberark_session }}'
@@ -171,7 +171,7 @@ EXAMPLES = r"""
   cyberark_user:
     username: Username
     new_password: password
-    disabled: no
+    disabled: false
     state: present
     cyberark_session: '{{ cyberark_session }}'
 

--- a/roles/aimprovider/tasks/installAIMProvider.yml
+++ b/roles/aimprovider/tasks/installAIMProvider.yml
@@ -58,7 +58,7 @@
   - name: Verify status of service after installing Provider
     command: service aimprv status
     register: command_result
-    ignore_errors: yes
+    ignore_errors: true
     args:
       warn: false
 

--- a/roles/aimprovider/tasks/main.yml
+++ b/roles/aimprovider/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Verify status of aimprv service initially
   command: service aimprv status
   register: service_already_running
-  ignore_errors: yes
+  ignore_errors: true
   changed_when: false
   args:
     warn: false

--- a/roles/aimprovider/tasks/uninstallAIMProvider.yml
+++ b/roles/aimprovider/tasks/uninstallAIMProvider.yml
@@ -31,7 +31,7 @@
       state: absent
       cyberark_session: "{{ cyberark_session }}"
     register: cyberarkaction
-    ignore_errors: yes
+    ignore_errors: true
     when: (cyberark_session.token is defined)
 
   # debug:

--- a/tests/change_test.yml
+++ b/tests/change_test.yml
@@ -9,7 +9,7 @@
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 

--- a/tests/changepolicy.yml
+++ b/tests/changepolicy.yml
@@ -9,7 +9,7 @@
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 

--- a/tests/deprovision_account.yml
+++ b/tests/deprovision_account.yml
@@ -9,7 +9,7 @@
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 

--- a/tests/deprovision_user.yml
+++ b/tests/deprovision_user.yml
@@ -9,7 +9,7 @@
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 

--- a/tests/disable_user.yml
+++ b/tests/disable_user.yml
@@ -9,7 +9,7 @@
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 

--- a/tests/enable_user.yml
+++ b/tests/enable_user.yml
@@ -9,7 +9,7 @@
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 

--- a/tests/provision_account.yml
+++ b/tests/provision_account.yml
@@ -9,7 +9,7 @@
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 

--- a/tests/provision_user.yml
+++ b/tests/provision_user.yml
@@ -9,7 +9,7 @@
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 

--- a/tests/reset_user_password.yml
+++ b/tests/reset_user_password.yml
@@ -9,7 +9,7 @@
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -9,7 +9,7 @@
     - name: Logon to CyberArk Vault using PAS Web Services SDK
       cyberark_authentication:
         api_base_url: "http://components.cyberark.local"
-        validate_certs: no
+        validate_certs: false
         username: "bizdev"
         password: "Cyberark1"
 


### PR DESCRIPTION
Standardize boolean values to use "true" or "false", according to issue #54.

### Connected Issue/Story

Resolves #54

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
