### PR TITLE
Adding the ability to override the context path

### DIFF
--- a/docs/cyberark_credential.md
+++ b/docs/cyberark_credential.md
@@ -124,4 +124,14 @@ options:
   result:
      { api_base_url }"/AIMWebService/api/Accounts?AppId="{ app_id }"&Query="{ query }"&ConnectionTimeout="{ connection_timeout }"&QueryFormat="{ query_format }"&FailRequestOnPasswordChange="{ fail_request_on_password_change }
      
+- name: credential retrieval custom path
+  cyberark_credential:
+    api_base_url: "http://10.10.0.1"
+    app_id: "TestID"
+    query: "Safe=test;UserName=admin"
+    path: AimWebServiceCustom
+  register: result
+  
+  result:
+     { api_base_url } { path } "?AppId="{ app_id }"&Query="{ query }
 ```

--- a/plugins/modules/cyberark_credential.py
+++ b/plugins/modules/cyberark_credential.py
@@ -98,6 +98,12 @@ options:
             - Reason for requesting credential if required by policy;
             - It must be specified if the Policy managing the object
             - requires it.
+    path:
+        type: str
+        required: false
+        description:
+            - String override for the context path
+
 """
 
 EXAMPLES = """
@@ -225,17 +231,22 @@ def retrieve_credential(module):
     fail_request_on_password_change = module.params["fail_request_on_password_change"]
     client_cert = None
     client_key = None
+    path = "/AIMWebService/api/Accounts"
 
     if "client_cert" in module.params:
         client_cert = module.params["client_cert"]
     if "client_key" in module.params:
         client_key = module.params["client_key"]
 
+    if "path" in module.params:
+        path = module.params["path"] 
+
     end_point = (
-        "/AIMWebService/api/Accounts?AppId=%s&Query=%s&"
+        "%s?AppId=%s&Query=%s&"
         "ConnectionTimeout=%s&QueryFormat=%s"
         "&FailRequestOnPasswordChange=%s"
     ) % (
+        path,
         quote(app_id),
         quote(query),
         connection_timeout,


### PR DESCRIPTION
### Desired Outcome
It's unlikely to be accepted as there's no community contribution, but submitting anyway.

As outlined in [this github issue](https://github.com/cyberark/ansible-security-automation-collection/issues/56), sometimes organizations may deploy their CCP agents to non-standard paths. This seeks to provide users of the module the ability to override the default path. 

### Implemented Changes
In the cyberark_credential class
- Updated the Ansible documentation to add a new, optional 'path' argument
- Updated the module to use the optional path instead of /AIMWebService/api/Accounts if it's been set

Also updates sample playbooks to include an example of its use

### Connected Issue/Story

Resolves [GitHub Issue 56](https://github.com/cyberark/ansible-security-automation-collection/issues/56)

### Definition of Done

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
