### PR TITLE
add support for custom application paths for CCP in cyberark_credential

### DIFF
--- a/plugins/modules/cyberark_credential.py
+++ b/plugins/modules/cyberark_credential.py
@@ -335,6 +335,7 @@ def main():
         "validate_certs": {"type": "bool", "default": True},
         "client_cert": {"type": "str", "required": False},
         "client_key": {"type": "str", "required": False, "no_log": True},
+        "path": {"type": "str", "required": False, "no_log": False},
     }
 
     module = AnsibleModule(argument_spec=fields, supports_check_mode=True)


### PR DESCRIPTION
### Desired Outcome
name: credential retrieval custom path
    cyberark_credential:
    api_base_url: "http://10.10.0.1/"
    app_id: "TestID"
    query: "Safe=test;UserName=admin"
    path: AimWebServiceCustom
    register: result

Should return the result:

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

The issue is fixed by adjusted the following file:
ansible-security-automation-collection/plugins/modules/cyberark_credential.py

In the main function we've added the following to the end of the fields (line 338):

"path": {"type": "str", "required": False, "no_log": False},

### Connected Issue/Story

Resolves #72 

CyberArk internal issue ID: 03705944 

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
