### PR TITLE
Add docs for updating password in vault only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 1.0.29
 
+- Added documentation to update password only in Vault
+
+## 1.0.28
+
+- Added ability to retrieve password
+
+## 1.0.27
+
 - Fixed Pep8 & pylint for publication in Automation Hub
 
 ## 1.0.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.27
+## 1.0.29
 
 - Fixed Pep8 & pylint for publication in Automation Hub
 

--- a/docs/cyberark_account.md
+++ b/docs/cyberark_account.md
@@ -281,7 +281,7 @@ options:
         new_secret: "Ama123ah12@#!Xaamdjbdkl@#112"
         state: present
         cyberark_session: "{{ cyberark_session }}"
-      register: reconcileaccount
+      register: updateaccount
 
     - name: Logoff from CyberArk Vault
       cyberark.pas.cyberark_authentication:

--- a/docs/cyberark_account.md
+++ b/docs/cyberark_account.md
@@ -270,6 +270,18 @@ options:
         state: present
         cyberark_session: "{{ cyberark_session }}"
       register: reconcileaccount
+    
+    - name: Update password only in VAULT
+      cyberark.pas.cyberark_account:
+        identified_by: "address,username"
+        safe: "Domain_Admins"
+        address: "prod.cyberark.local"
+        username: "admin"
+        platform_id: Generic
+        new_secret: "Ama123ah12@#!Xaamdjbdkl@#112"
+        state: present
+        cyberark_session: "{{ cyberark_session }}"
+      register: reconcileaccount
 
     - name: Logoff from CyberArk Vault
       cyberark.pas.cyberark_authentication:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "cyberark"
 name: "pas"
-version: "1.0.27"
+version: "1.0.29"
 readme: README.md
 authors:
     - CyberArk Business Development (@cyberark-bizdev)

--- a/plugins/modules/cyberark_account.py
+++ b/plugins/modules/cyberark_account.py
@@ -258,7 +258,7 @@ EXAMPLES = """
         new_secret: "Ama123ah12@#!Xaamdjbdkl@#112"
         state: present
         cyberark_session: "{{ cyberark_session }}"
-      register: reconcileaccount
+      register: updateaccount
 
     - name: Logoff from CyberArk Vault
       cyberark_authentication:

--- a/plugins/modules/cyberark_account.py
+++ b/plugins/modules/cyberark_account.py
@@ -231,9 +231,7 @@ EXAMPLES = """
         cyberark_session: "{{ cyberark_session }}"
       register: cyberarkaction
 
-    - name:
-        - Rotate credential via reconcile and providing the password to
-          bechanged to.
+    - name: Rotate credential via reconcile and providing the password to be changed to
       cyberark_account:
         identified_by: "address,username"
         safe: "Domain_Admins"
@@ -246,6 +244,18 @@ EXAMPLES = """
             new_secret: "Ama123ah12@#!Xaamdjbdkl@#112"
             management_action: "reconcile"
             automatic_management_enabled: true
+        state: present
+        cyberark_session: "{{ cyberark_session }}"
+      register: reconcileaccount
+
+    - name: Update password only in VAULT
+      cyberark.pas.cyberark_account:
+        identified_by: "address,username"
+        safe: "Domain_Admins"
+        address: "prod.cyberark.local"
+        username: "admin"
+        platform_id: Generic
+        new_secret: "Ama123ah12@#!Xaamdjbdkl@#112"
         state: present
         cyberark_session: "{{ cyberark_session }}"
       register: reconcileaccount


### PR DESCRIPTION
### Desired Outcome

Provide documentation to update the password only in the vault. This is necessary for accounts that are not managed by CPM, such as a static/generic account.

### Implemented Changes

Updated documentation for the `cyberark_account` module.

### Connected Issue/Story

n/a

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
