### PR TITLE
Added timeout option to cyberark account module

### DIFF
--- a/docs/cyberark_account.md
+++ b/docs/cyberark_account.md
@@ -118,17 +118,23 @@ options:
         required: false
         default: true
         type: bool
+    timeout:
+        description:
+            - An integer value of seconds of the allowed time before the requests fail because of a timeout.
+        type: int
+        default: 30
+        required: false
     cyberark_session:
         description:
             - Dictionary set by a CyberArk authentication containing the different values to perform actions on a logged-on CyberArk session, please see M(cyberark_authentication) module for an example of cyberark_session.
         required: true
         type: dict
-    identified_by: 
+    identified_by:
         description:
             - When an API call is made to Get Accounts, often times the default parameters passed will identify more than one account. This parameter is used to confidently identify a single account when the default query can return multiple results.
         required: false
         default: username,address,platform_id
-        type: str        
+        type: str
     safe:
         description:
             - The safe in the Vault where the privileged account is to be located
@@ -204,7 +210,7 @@ options:
             suboptions:
                 remote_machines:
                     description:
-                        - List of targets allowed for this account 
+                        - List of targets allowed for this account
                     type: str
                 access_restricted_to_remote_machines:
                     description:
@@ -253,7 +259,7 @@ options:
         state: present
         cyberark_session: "{{ cyberark_session }}"
       register: cyberarkaction
-    
+
     - name: Rotate credential via reconcile and providing the password to be changed to
       cyberark.pas.cyberark_account:
         identified_by: "address,username"
@@ -270,7 +276,7 @@ options:
         state: present
         cyberark_session: "{{ cyberark_session }}"
       register: reconcileaccount
-    
+
     - name: Update password only in VAULT
       cyberark.pas.cyberark_account:
         identified_by: "address,username"


### PR DESCRIPTION
### Desired Outcome

Support for a timeout parameter that specifies the timeout for `open_url` calls in the cyberark_account module.

### Implemented Changes

Added a new ansible parameter `timeout` to the cyberark_account module and pass the timeout on to the `open_url` calls within the module. The new parameter is optional and has a default of 30 seconds.

### Connected Issue/Story

Resolves #[28]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
