### PR TITLE
fix: path param for cyberark_credential module is not defined

### DIFF
--- a/plugins/modules/cyberark_credential.py
+++ b/plugins/modules/cyberark_credential.py
@@ -335,6 +335,7 @@ def main():
         "validate_certs": {"type": "bool", "default": True},
         "client_cert": {"type": "str", "required": False},
         "client_key": {"type": "str", "required": False, "no_log": True},
+        "path": {"type": "str", "required": False},
     }
 
     module = AnsibleModule(argument_spec=fields, supports_check_mode=True)


### PR DESCRIPTION
### Desired Outcome

This is a fix to add `path` param to the `cyberark_credential` module. Without this fix, task fails with "Unsupported parameters" error message when `path` is specified.

Sample Task
```yaml
- name: Credential retrieval custom path
  cyberark.pas.cyberark_credential:
    api_base_url: 'https://example.com'
    app_id: 'TestID'
    query: 'Safe=test;UserName=admin'
    path: AIMWebServiceKrb/api/Accounts
  register: result
```
Error:
>  msg: 'Unsupported parameters for (cyberark.pas.cyberark_credential) module: **path**. Supported parameters include: api_base_url, app_id, client_cert, client_key, connection_timeout, fail_request_on_password_change, query, query_format, reason, validate_certs.'

### Implemented Changes

Added `path` param to Ansible module argument spec.

### Connected Issue/Story

Originally implemented in https://github.com/cyberark/ansible-security-automation-collection/pull/61

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
