### PR TITLE
feat: add `use_gssapi` param to `cyberark_credential` module to support Kerberos authentication

### DIFF
--- a/plugins/modules/cyberark_credential.py
+++ b/plugins/modules/cyberark_credential.py
@@ -231,12 +231,15 @@ def retrieve_credential(module):
     fail_request_on_password_change = module.params["fail_request_on_password_change"]
     client_cert = None
     client_key = None
+    use_gssapi = None
     path = "/AIMWebService/api/Accounts"
 
     if "client_cert" in module.params:
         client_cert = module.params["client_cert"]
     if "client_key" in module.params:
         client_key = module.params["client_key"]
+    if "use_gssapi" in module.params:
+        use_gssapi = module.params["use_gssapi"]
 
     if "path" in module.params:
         path = module.params["path"]
@@ -269,6 +272,7 @@ def retrieve_credential(module):
             validate_certs=validate_certs,
             client_cert=client_cert,
             client_key=client_key,
+            use_gssapi=use_gssapi,
         )
 
     except (HTTPError, HTTPException) as http_exception:
@@ -335,6 +339,8 @@ def main():
         "validate_certs": {"type": "bool", "default": True},
         "client_cert": {"type": "str", "required": False},
         "client_key": {"type": "str", "required": False, "no_log": True},
+        "client_key": {"type": "str", "required": False, "no_log": True},
+        "use_gssapi": {"type": "bool", "required": False},
     }
 
     module = AnsibleModule(argument_spec=fields, supports_check_mode=True)


### PR DESCRIPTION
### Desired Outcome

Be able to use Kerberos authentication with custom paths to fetch credentials.

Sample usage
Need to set `KRB5CCNAME` as specified in the `use_gssapi` param docs [here](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html#parameter-use_gssapi).
```sh
export KRB5CCNAME=/tmp/krb5cc_xxx
kinit user@REALM
```

```yaml
- name: Credential retrieval custom path
  cyberark_credential_new:
    api_base_url: 'https://example.com'
    app_id: TestApp
    query: 'Safe=TestSafe;UserName=admin'
    path: /AIMWebServiceKrb/api/Accounts
    validate_certs: false
    use_gssapi: true
  register: result
  delegate_to: localhost
```

### Implemented Changes

- Add a `use_gssapi` module parameter to enable GSSAPI authentication in calls to `ansible.module_utils.urls.open_url`.

### Connected Issue/Story

Resolves #84 

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
